### PR TITLE
Enable toggling of sustained tone on click

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -784,6 +784,35 @@ console.log("Static site loaded!");
     marks.push({ x, y, voice, effects: keys });
   };
 
+  // Find the nearest sustained mark within a hit radius; returns its index or -1
+  const findMarkIndexNear = (x, y, radius = 14) => {
+    let idx = -1;
+    let bestD2 = radius * radius;
+    for (let i = 0; i < marks.length; i++) {
+      const m = marks[i];
+      const dx = m.x - x;
+      const dy = m.y - y;
+      const d2 = dx * dx + dy * dy;
+      if (d2 <= bestD2) {
+        bestD2 = d2;
+        idx = i;
+      }
+    }
+    return idx;
+  };
+
+  // Remove a sustained mark at a location (if present). Returns true if removed.
+  const removeSustainedAt = (x, y, radius = 14) => {
+    const idx = findMarkIndexNear(x, y, radius);
+    if (idx >= 0) {
+      const m = marks[idx];
+      try { m.voice.stop(); } catch (_) {}
+      marks.splice(idx, 1);
+      return true;
+    }
+    return false;
+  };
+
   const clearAll = () => {
     for (const m of marks) {
       try { m.voice.stop(); } catch (_) {}
@@ -860,10 +889,13 @@ console.log("Static site loaded!");
     stopPointerVoice();
   });
 
-  // Click to mark and sustain
+  // Click to toggle sustain at location
   canvas.addEventListener('click', (evt) => {
     const { x, y } = getLocalPos(evt);
-    addSustainedMark(x, y);
+    // If clicking near an existing mark, remove it; else add a new sustained note.
+    if (!removeSustainedAt(x, y, 16)) {
+      addSustainedMark(x, y);
+    }
   });
 
   // Clear button


### PR DESCRIPTION
This pull request adds functionality to toggle sustained tones when clicking on the canvas. Previously, clicking would only add a sustained tone; now, if a user clicks near an existing sustained mark, it will be removed instead. This was achieved by implementing two new functions: `findMarkIndexNear` to locate a sustained mark within a specified radius, and `removeSustainedAt` to remove it if present. The click event listener was updated to incorporate this behavior.

---

> This pull request was co-created with Cosine Genie

Original Task: [another-music-toy-noise/mw7udsdycntt](https://cosine.wtf/cosine-stg/another-music-toy-noise/task/mw7udsdycntt)
Author: Curtis Huang
